### PR TITLE
Cache forecast with expiry

### DIFF
--- a/example_cached_forecast.txt
+++ b/example_cached_forecast.txt
@@ -1,0 +1,3088 @@
+{
+   "expires_at": "2024-03-17 18:01:52 +0000 GMT",
+   "geometry" : {
+      "coordinates" : [
+         0,
+         51.5,
+         4
+      ],
+      "type" : "Point"
+   },
+   "properties" : {
+      "meta" : {
+         "units" : {
+            "air_pressure_at_sea_level" : "hPa",
+            "air_temperature" : "celsius",
+            "cloud_area_fraction" : "%",
+            "precipitation_amount" : "mm",
+            "relative_humidity" : "%",
+            "wind_from_direction" : "degrees",
+            "wind_speed" : "m/s"
+         },
+         "updated_at" : "2024-03-17T13:26:46Z"
+      },
+      "timeseries" : [
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.1,
+                     "air_temperature" : 15.2,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 73.6,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-17T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013,
+                     "air_temperature" : 15.2,
+                     "cloud_area_fraction" : 50.8,
+                     "relative_humidity" : 73.6,
+                     "wind_from_direction" : 235.1,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-17T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.8,
+                     "air_temperature" : 15.6,
+                     "cloud_area_fraction" : 28.1,
+                     "relative_humidity" : 71.3,
+                     "wind_from_direction" : 234.2,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.9,
+                     "air_temperature" : 14.8,
+                     "cloud_area_fraction" : 23.4,
+                     "relative_humidity" : 74.5,
+                     "wind_from_direction" : 214.1,
+                     "wind_speed" : 4.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013,
+                     "air_temperature" : 12.6,
+                     "cloud_area_fraction" : 53.1,
+                     "relative_humidity" : 82.2,
+                     "wind_from_direction" : 202,
+                     "wind_speed" : 5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.6,
+                     "air_temperature" : 11,
+                     "cloud_area_fraction" : 91.4,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 212.8,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.3,
+                     "wind_from_direction" : 220,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 10.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.7,
+                     "wind_from_direction" : 229.2,
+                     "wind_speed" : 4.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.6,
+                     "air_temperature" : 10.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.5,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 3.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.4,
+                     "wind_from_direction" : 240.1,
+                     "wind_speed" : 3.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95,
+                     "wind_from_direction" : 237.7,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 42.2,
+                     "relative_humidity" : 96.8,
+                     "wind_from_direction" : 240.3,
+                     "wind_speed" : 2.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.4,
+                     "air_temperature" : 7.4,
+                     "cloud_area_fraction" : 25.8,
+                     "relative_humidity" : 97.9,
+                     "wind_from_direction" : 230,
+                     "wind_speed" : 3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 7.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 97.8,
+                     "wind_from_direction" : 233,
+                     "wind_speed" : 3.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 97.3,
+                     "wind_from_direction" : 238.6,
+                     "wind_speed" : 3.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.9,
+                     "wind_from_direction" : 239.3,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.7,
+                     "wind_from_direction" : 242,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.3,
+                     "air_temperature" : 8.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.7,
+                     "wind_from_direction" : 249.6,
+                     "wind_speed" : 4.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T07:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.7,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.2,
+                     "wind_from_direction" : 251.2,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T08:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 9.7,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 85.4,
+                     "wind_from_direction" : 248.3,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T09:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 11.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 77.5,
+                     "wind_from_direction" : 243.1,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T10:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.8,
+                     "air_temperature" : 12.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 74.9,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T11:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.7,
+                     "air_temperature" : 13.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.1,
+                     "wind_from_direction" : 228,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.2,
+                     "air_temperature" : 14,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 70.4,
+                     "wind_from_direction" : 223.3,
+                     "wind_speed" : 4.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T13:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 14.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 69.7,
+                     "wind_from_direction" : 220.3,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.4,
+                     "air_temperature" : 14.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 71.6,
+                     "wind_from_direction" : 220.5,
+                     "wind_speed" : 6.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-18T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 13.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.3,
+                     "wind_from_direction" : 219.3,
+                     "wind_speed" : 6.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 13.1,
+                     "cloud_area_fraction" : 95.3,
+                     "relative_humidity" : 74.4,
+                     "wind_from_direction" : 219.2,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 11.8,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 80.2,
+                     "wind_from_direction" : 211.2,
+                     "wind_speed" : 4.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 93.7,
+                     "relative_humidity" : 90,
+                     "wind_from_direction" : 201.4,
+                     "wind_speed" : 4.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 9.4,
+                     "cloud_area_fraction" : 95.3,
+                     "relative_humidity" : 92.9,
+                     "wind_from_direction" : 212.6,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 21.1,
+                     "relative_humidity" : 92.8,
+                     "wind_from_direction" : 219.6,
+                     "wind_speed" : 5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 9.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 92,
+                     "wind_from_direction" : 214.9,
+                     "wind_speed" : 4.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.1,
+                     "wind_from_direction" : 219.8,
+                     "wind_speed" : 4.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.6,
+                     "wind_from_direction" : 222.4,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 10.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 87.6,
+                     "wind_from_direction" : 213.5,
+                     "wind_speed" : 5.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.4,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.5,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 210.6,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.2,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 92.1,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 42.2,
+                     "relative_humidity" : 93.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 74.2,
+                     "relative_humidity" : 93.6,
+                     "wind_from_direction" : 203.8,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.4,
+                     "air_temperature" : 9.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T07:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.7,
+                     "air_temperature" : 10.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 86.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 6.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T08:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 11,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 84.8,
+                     "wind_from_direction" : 206.9,
+                     "wind_speed" : 6.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T09:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.1,
+                     "air_temperature" : 11.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 85.1,
+                     "wind_from_direction" : 199.9,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T10:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 11.7,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 84,
+                     "wind_from_direction" : 204.8,
+                     "wind_speed" : 7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T11:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.1,
+                     "air_temperature" : 12.8,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 81.4,
+                     "wind_from_direction" : 214.1,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 14,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 74.9,
+                     "wind_from_direction" : 214.9,
+                     "wind_speed" : 6.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T13:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.8,
+                     "air_temperature" : 14.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.1,
+                     "wind_from_direction" : 221.6,
+                     "wind_speed" : 6.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 15,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 69.5,
+                     "wind_from_direction" : 222.3,
+                     "wind_speed" : 6.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 14.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 71.3,
+                     "wind_from_direction" : 221.3,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 13.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 76,
+                     "wind_from_direction" : 217.1,
+                     "wind_speed" : 4.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 12.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 81.5,
+                     "wind_from_direction" : 219.1,
+                     "wind_speed" : 3.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.6,
+                     "air_temperature" : 10.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 87.8,
+                     "wind_from_direction" : 216,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.8,
+                     "air_temperature" : 10.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 92.1,
+                     "wind_from_direction" : 210.3,
+                     "wind_speed" : 3.2
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016,
+                     "air_temperature" : 9.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.6,
+                     "wind_from_direction" : 199.1,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.7
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.2,
+                     "air_temperature" : 9.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.7,
+                     "wind_from_direction" : 201.2,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.1,
+                     "air_temperature" : 8.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95.6,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 2.9
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 9.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 204.4,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.8
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.4,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 203.7,
+                     "wind_speed" : 2.4
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.1,
+                     "air_temperature" : 9.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.3,
+                     "wind_from_direction" : 198,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.7
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.2,
+                     "wind_from_direction" : 187.5,
+                     "wind_speed" : 2.1
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 10,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95,
+                     "wind_from_direction" : 165.3,
+                     "wind_speed" : 2.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.8,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.2,
+                     "wind_from_direction" : 153.7,
+                     "wind_speed" : 2.4
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.7,
+                     "air_temperature" : 10,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.8,
+                     "wind_from_direction" : 141.8,
+                     "wind_speed" : 2.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.5,
+                     "air_temperature" : 16.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 62.9,
+                     "wind_from_direction" : 194.8,
+                     "wind_speed" : 3.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 12.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 78.4,
+                     "wind_from_direction" : 205,
+                     "wind_speed" : 1.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 8.7,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 94.6,
+                     "wind_from_direction" : 242.8,
+                     "wind_speed" : 3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-21T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.3,
+                     "air_temperature" : 7.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 248.8,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-21T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.5,
+                     "air_temperature" : 10.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.9,
+                     "wind_from_direction" : 228.4,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-21T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 11.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 82.4,
+                     "wind_from_direction" : 234.4,
+                     "wind_speed" : 7.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-21T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.9,
+                     "air_temperature" : 12,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.7,
+                     "wind_from_direction" : 241.7,
+                     "wind_speed" : 6.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-22T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1007.9,
+                     "air_temperature" : 12.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 91.1,
+                     "wind_from_direction" : 238.9,
+                     "wind_speed" : 6.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-22T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1004.7,
+                     "air_temperature" : 13.4,
+                     "cloud_area_fraction" : 43.7,
+                     "relative_humidity" : 59.1,
+                     "wind_from_direction" : 261.3,
+                     "wind_speed" : 8.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-22T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1001.1,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 9.4,
+                     "relative_humidity" : 61.1,
+                     "wind_from_direction" : 252.6,
+                     "wind_speed" : 7.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-22T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 997.4,
+                     "air_temperature" : 7.1,
+                     "cloud_area_fraction" : 61.7,
+                     "relative_humidity" : 73,
+                     "wind_from_direction" : 240.4,
+                     "wind_speed" : 7.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-23T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 996.4,
+                     "air_temperature" : 6.5,
+                     "cloud_area_fraction" : 85.2,
+                     "relative_humidity" : 76.4,
+                     "wind_from_direction" : 265.9,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               }
+            },
+            "time" : "2024-03-23T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 999.1,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 69.8,
+                     "wind_from_direction" : 300.3,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 2.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-23T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1003.4,
+                     "air_temperature" : 7.2,
+                     "cloud_area_fraction" : 39.1,
+                     "relative_humidity" : 80.1,
+                     "wind_from_direction" : 335.2,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-23T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1009.7,
+                     "air_temperature" : 5.7,
+                     "cloud_area_fraction" : 35.2,
+                     "relative_humidity" : 79.7,
+                     "wind_from_direction" : 346.1,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               }
+            },
+            "time" : "2024-03-24T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.6,
+                     "air_temperature" : 3.1,
+                     "cloud_area_fraction" : 18.7,
+                     "relative_humidity" : 76.1,
+                     "wind_from_direction" : 337.7,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               }
+            },
+            "time" : "2024-03-24T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1019.9,
+                     "air_temperature" : 8.1,
+                     "cloud_area_fraction" : 57.8,
+                     "relative_humidity" : 53.5,
+                     "wind_from_direction" : 349.3,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-24T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.5,
+                     "air_temperature" : 6.4,
+                     "cloud_area_fraction" : 73.4,
+                     "relative_humidity" : 62.9,
+                     "wind_from_direction" : 7.7,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-24T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.3,
+                     "air_temperature" : 1.3,
+                     "cloud_area_fraction" : 5.5,
+                     "relative_humidity" : 88.9,
+                     "wind_from_direction" : 14.4,
+                     "wind_speed" : 2.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-25T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.8,
+                     "air_temperature" : -1.4,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 97.8,
+                     "wind_from_direction" : 281.4,
+                     "wind_speed" : 1.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_day"
+                  }
+               }
+            },
+            "time" : "2024-03-25T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.3,
+                     "air_temperature" : 8.8,
+                     "cloud_area_fraction" : 72.7,
+                     "relative_humidity" : 52.1,
+                     "wind_from_direction" : 284.2,
+                     "wind_speed" : 0.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-25T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.8,
+                     "air_temperature" : 8.3,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 57.8,
+                     "wind_from_direction" : 167.8,
+                     "wind_speed" : 0.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-25T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1024.1,
+                     "air_temperature" : 2.8,
+                     "cloud_area_fraction" : 75.8,
+                     "relative_humidity" : 88.5,
+                     "wind_from_direction" : 222.5,
+                     "wind_speed" : 1.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-26T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.3,
+                     "air_temperature" : 4.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.4,
+                     "wind_from_direction" : 222.8,
+                     "wind_speed" : 2.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-26T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.7,
+                     "air_temperature" : 11.6,
+                     "cloud_area_fraction" : 82,
+                     "relative_humidity" : 75.9,
+                     "wind_from_direction" : 252.4,
+                     "wind_speed" : 0.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-26T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.1,
+                     "air_temperature" : 13.2,
+                     "cloud_area_fraction" : 28.1,
+                     "relative_humidity" : 73.8,
+                     "wind_from_direction" : 55.2,
+                     "wind_speed" : 1.2
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               }
+            },
+            "time" : "2024-03-26T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1025,
+                     "air_temperature" : 5.6,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 99.5,
+                     "wind_from_direction" : 83.6,
+                     "wind_speed" : 2.1
+                  }
+               }
+            },
+            "time" : "2024-03-27T00:00:00Z"
+         }
+      ]
+   },
+   "type" : "Feature"
+}

--- a/example_response.txt
+++ b/example_response.txt
@@ -1,0 +1,3087 @@
+{
+   "geometry" : {
+      "coordinates" : [
+         0,
+         51.5,
+         4
+      ],
+      "type" : "Point"
+   },
+   "properties" : {
+      "meta" : {
+         "units" : {
+            "air_pressure_at_sea_level" : "hPa",
+            "air_temperature" : "celsius",
+            "cloud_area_fraction" : "%",
+            "precipitation_amount" : "mm",
+            "relative_humidity" : "%",
+            "wind_from_direction" : "degrees",
+            "wind_speed" : "m/s"
+         },
+         "updated_at" : "2024-03-17T13:26:46Z"
+      },
+      "timeseries" : [
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.1,
+                     "air_temperature" : 15.2,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 73.6,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-17T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013,
+                     "air_temperature" : 15.2,
+                     "cloud_area_fraction" : 50.8,
+                     "relative_humidity" : 73.6,
+                     "wind_from_direction" : 235.1,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-17T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.8,
+                     "air_temperature" : 15.6,
+                     "cloud_area_fraction" : 28.1,
+                     "relative_humidity" : 71.3,
+                     "wind_from_direction" : 234.2,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.9,
+                     "air_temperature" : 14.8,
+                     "cloud_area_fraction" : 23.4,
+                     "relative_humidity" : 74.5,
+                     "wind_from_direction" : 214.1,
+                     "wind_speed" : 4.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013,
+                     "air_temperature" : 12.6,
+                     "cloud_area_fraction" : 53.1,
+                     "relative_humidity" : 82.2,
+                     "wind_from_direction" : 202,
+                     "wind_speed" : 5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.6,
+                     "air_temperature" : 11,
+                     "cloud_area_fraction" : 91.4,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 212.8,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-17T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.3,
+                     "wind_from_direction" : 220,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 10.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.7,
+                     "wind_from_direction" : 229.2,
+                     "wind_speed" : 4.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.6,
+                     "air_temperature" : 10.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.5,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 3.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.4,
+                     "wind_from_direction" : 240.1,
+                     "wind_speed" : 3.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-17T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95,
+                     "wind_from_direction" : 237.7,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 42.2,
+                     "relative_humidity" : 96.8,
+                     "wind_from_direction" : 240.3,
+                     "wind_speed" : 2.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.4,
+                     "air_temperature" : 7.4,
+                     "cloud_area_fraction" : 25.8,
+                     "relative_humidity" : 97.9,
+                     "wind_from_direction" : 230,
+                     "wind_speed" : 3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 7.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 97.8,
+                     "wind_from_direction" : 233,
+                     "wind_speed" : 3.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 97.3,
+                     "wind_from_direction" : 238.6,
+                     "wind_speed" : 3.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.9,
+                     "wind_from_direction" : 239.3,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015,
+                     "air_temperature" : 8.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.7,
+                     "wind_from_direction" : 242,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.3,
+                     "air_temperature" : 8.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.7,
+                     "wind_from_direction" : 249.6,
+                     "wind_speed" : 4.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T07:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.7,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.2,
+                     "wind_from_direction" : 251.2,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T08:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 9.7,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 85.4,
+                     "wind_from_direction" : 248.3,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T09:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 11.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 77.5,
+                     "wind_from_direction" : 243.1,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T10:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.8,
+                     "air_temperature" : 12.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 74.9,
+                     "wind_from_direction" : 236.5,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T11:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.7,
+                     "air_temperature" : 13.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.1,
+                     "wind_from_direction" : 228,
+                     "wind_speed" : 4.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.2,
+                     "air_temperature" : 14,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 70.4,
+                     "wind_from_direction" : 223.3,
+                     "wind_speed" : 4.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T13:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 14.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 69.7,
+                     "wind_from_direction" : 220.3,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.4,
+                     "air_temperature" : 14.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 71.6,
+                     "wind_from_direction" : 220.5,
+                     "wind_speed" : 6.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-18T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 13.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.3,
+                     "wind_from_direction" : 219.3,
+                     "wind_speed" : 6.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 13.1,
+                     "cloud_area_fraction" : 95.3,
+                     "relative_humidity" : 74.4,
+                     "wind_from_direction" : 219.2,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 11.8,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 80.2,
+                     "wind_from_direction" : 211.2,
+                     "wind_speed" : 4.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-18T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 93.7,
+                     "relative_humidity" : 90,
+                     "wind_from_direction" : 201.4,
+                     "wind_speed" : 4.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 9.4,
+                     "cloud_area_fraction" : 95.3,
+                     "relative_humidity" : 92.9,
+                     "wind_from_direction" : 212.6,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 21.1,
+                     "relative_humidity" : 92.8,
+                     "wind_from_direction" : 219.6,
+                     "wind_speed" : 5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 9.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 92,
+                     "wind_from_direction" : 214.9,
+                     "wind_speed" : 4.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 89.1,
+                     "wind_from_direction" : 219.8,
+                     "wind_speed" : 4.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-18T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.6,
+                     "wind_from_direction" : 222.4,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.2,
+                     "air_temperature" : 10.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 87.6,
+                     "wind_from_direction" : 213.5,
+                     "wind_speed" : 5.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.4,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.5,
+                     "air_temperature" : 10.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 210.6,
+                     "wind_speed" : 5.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-19T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.2,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 98.4,
+                     "relative_humidity" : 92.1,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 42.2,
+                     "relative_humidity" : 93.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 5.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 74.2,
+                     "relative_humidity" : 93.6,
+                     "wind_from_direction" : 203.8,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.4,
+                     "air_temperature" : 9.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 90.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T07:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.7,
+                     "air_temperature" : 10.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 86.3,
+                     "wind_from_direction" : 210,
+                     "wind_speed" : 6.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T08:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 11,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 84.8,
+                     "wind_from_direction" : 206.9,
+                     "wind_speed" : 6.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T09:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.1,
+                     "air_temperature" : 11.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 85.1,
+                     "wind_from_direction" : 199.9,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T10:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 11.7,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 84,
+                     "wind_from_direction" : 204.8,
+                     "wind_speed" : 7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T11:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.1,
+                     "air_temperature" : 12.8,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 81.4,
+                     "wind_from_direction" : 214.1,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.9,
+                     "air_temperature" : 14,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 74.9,
+                     "wind_from_direction" : 214.9,
+                     "wind_speed" : 6.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T13:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.8,
+                     "air_temperature" : 14.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.1,
+                     "wind_from_direction" : 221.6,
+                     "wind_speed" : 6.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T14:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 15,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 69.5,
+                     "wind_from_direction" : 222.3,
+                     "wind_speed" : 6.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T15:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.3,
+                     "air_temperature" : 14.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 71.3,
+                     "wind_from_direction" : 221.3,
+                     "wind_speed" : 5.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T16:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 13.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 76,
+                     "wind_from_direction" : 217.1,
+                     "wind_speed" : 4.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T17:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 12.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 81.5,
+                     "wind_from_direction" : 219.1,
+                     "wind_speed" : 3.6
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-19T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.6,
+                     "air_temperature" : 10.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 87.8,
+                     "wind_from_direction" : 216,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T19:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.8,
+                     "air_temperature" : 10.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 92.1,
+                     "wind_from_direction" : 210.3,
+                     "wind_speed" : 3.2
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T20:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016,
+                     "air_temperature" : 9.6,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.6,
+                     "wind_from_direction" : 199.1,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.7
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T21:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.2,
+                     "air_temperature" : 9.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.7,
+                     "wind_from_direction" : 201.2,
+                     "wind_speed" : 3.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T22:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.1,
+                     "air_temperature" : 8.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95.6,
+                     "wind_from_direction" : 213.2,
+                     "wind_speed" : 2.9
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-19T23:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.9,
+                     "air_temperature" : 9.4,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 204.4,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.4
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 1.8
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.4,
+                     "air_temperature" : 9.5,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 203.7,
+                     "wind_speed" : 2.4
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T01:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.1,
+                     "air_temperature" : 9.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.3,
+                     "wind_from_direction" : 198,
+                     "wind_speed" : 2.5
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.7
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T02:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.5,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 94.2,
+                     "wind_from_direction" : 187.5,
+                     "wind_speed" : 2.1
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-20T03:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014,
+                     "air_temperature" : 10,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 95,
+                     "wind_from_direction" : 165.3,
+                     "wind_speed" : 2.3
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T04:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.8,
+                     "air_temperature" : 10.2,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.2,
+                     "wind_from_direction" : 153.7,
+                     "wind_speed" : 2.4
+                  }
+               },
+               "next_1_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T05:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.7,
+                     "air_temperature" : 10,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 96.8,
+                     "wind_from_direction" : 141.8,
+                     "wind_speed" : 2.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.5,
+                     "air_temperature" : 16.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 62.9,
+                     "wind_from_direction" : 194.8,
+                     "wind_speed" : 3.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1013.3,
+                     "air_temperature" : 12.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 78.4,
+                     "wind_from_direction" : 205,
+                     "wind_speed" : 1.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-20T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.9,
+                     "air_temperature" : 8.7,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 94.6,
+                     "wind_from_direction" : 242.8,
+                     "wind_speed" : 3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-21T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1015.3,
+                     "air_temperature" : 7.8,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 93.9,
+                     "wind_from_direction" : 248.8,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-21T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1016.5,
+                     "air_temperature" : 10.9,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 72.9,
+                     "wind_from_direction" : 228.4,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.5
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-21T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.8,
+                     "air_temperature" : 11.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 82.4,
+                     "wind_from_direction" : 234.4,
+                     "wind_speed" : 7.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-21T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1012.9,
+                     "air_temperature" : 12,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.7,
+                     "wind_from_direction" : 241.7,
+                     "wind_speed" : 6.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrain"
+                  }
+               }
+            },
+            "time" : "2024-03-22T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1007.9,
+                     "air_temperature" : 12.1,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 91.1,
+                     "wind_from_direction" : 238.9,
+                     "wind_speed" : 6.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.3
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-22T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1004.7,
+                     "air_temperature" : 13.4,
+                     "cloud_area_fraction" : 43.7,
+                     "relative_humidity" : 59.1,
+                     "wind_from_direction" : 261.3,
+                     "wind_speed" : 8.5
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-22T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1001.1,
+                     "air_temperature" : 9.9,
+                     "cloud_area_fraction" : 9.4,
+                     "relative_humidity" : 61.1,
+                     "wind_from_direction" : 252.6,
+                     "wind_speed" : 7.8
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-22T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 997.4,
+                     "air_temperature" : 7.1,
+                     "cloud_area_fraction" : 61.7,
+                     "relative_humidity" : 73,
+                     "wind_from_direction" : 240.4,
+                     "wind_speed" : 7.4
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-23T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 996.4,
+                     "air_temperature" : 6.5,
+                     "cloud_area_fraction" : 85.2,
+                     "relative_humidity" : 76.4,
+                     "wind_from_direction" : 265.9,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               }
+            },
+            "time" : "2024-03-23T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 999.1,
+                     "air_temperature" : 9,
+                     "cloud_area_fraction" : 99.2,
+                     "relative_humidity" : 69.8,
+                     "wind_from_direction" : 300.3,
+                     "wind_speed" : 5.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "lightrainshowers_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 2.9
+                  },
+                  "summary" : {
+                     "symbol_code" : "rain"
+                  }
+               }
+            },
+            "time" : "2024-03-23T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1003.4,
+                     "air_temperature" : 7.2,
+                     "cloud_area_fraction" : 39.1,
+                     "relative_humidity" : 80.1,
+                     "wind_from_direction" : 335.2,
+                     "wind_speed" : 4.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-23T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1009.7,
+                     "air_temperature" : 5.7,
+                     "cloud_area_fraction" : 35.2,
+                     "relative_humidity" : 79.7,
+                     "wind_from_direction" : 346.1,
+                     "wind_speed" : 5.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               }
+            },
+            "time" : "2024-03-24T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1014.6,
+                     "air_temperature" : 3.1,
+                     "cloud_area_fraction" : 18.7,
+                     "relative_humidity" : 76.1,
+                     "wind_from_direction" : 337.7,
+                     "wind_speed" : 5.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.2
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               }
+            },
+            "time" : "2024-03-24T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1019.9,
+                     "air_temperature" : 8.1,
+                     "cloud_area_fraction" : 57.8,
+                     "relative_humidity" : 53.5,
+                     "wind_from_direction" : 349.3,
+                     "wind_speed" : 6.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-24T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.5,
+                     "air_temperature" : 6.4,
+                     "cloud_area_fraction" : 73.4,
+                     "relative_humidity" : 62.9,
+                     "wind_from_direction" : 7.7,
+                     "wind_speed" : 4.3
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-24T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.3,
+                     "air_temperature" : 1.3,
+                     "cloud_area_fraction" : 5.5,
+                     "relative_humidity" : 88.9,
+                     "wind_from_direction" : 14.4,
+                     "wind_speed" : 2.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-25T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.8,
+                     "air_temperature" : -1.4,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 97.8,
+                     "wind_from_direction" : 281.4,
+                     "wind_speed" : 1.7
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_day"
+                  }
+               }
+            },
+            "time" : "2024-03-25T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1026.3,
+                     "air_temperature" : 8.8,
+                     "cloud_area_fraction" : 72.7,
+                     "relative_humidity" : 52.1,
+                     "wind_from_direction" : 284.2,
+                     "wind_speed" : 0.1
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-25T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.8,
+                     "air_temperature" : 8.3,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 57.8,
+                     "wind_from_direction" : 167.8,
+                     "wind_speed" : 0.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "clearsky_night"
+                  }
+               }
+            },
+            "time" : "2024-03-25T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1024.1,
+                     "air_temperature" : 2.8,
+                     "cloud_area_fraction" : 75.8,
+                     "relative_humidity" : 88.5,
+                     "wind_from_direction" : 222.5,
+                     "wind_speed" : 1.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_night"
+                  }
+               }
+            },
+            "time" : "2024-03-26T00:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.3,
+                     "air_temperature" : 4.3,
+                     "cloud_area_fraction" : 100,
+                     "relative_humidity" : 88.4,
+                     "wind_from_direction" : 222.8,
+                     "wind_speed" : 2.2
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "cloudy"
+                  }
+               }
+            },
+            "time" : "2024-03-26T06:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.7,
+                     "air_temperature" : 11.6,
+                     "cloud_area_fraction" : 82,
+                     "relative_humidity" : 75.9,
+                     "wind_from_direction" : 252.4,
+                     "wind_speed" : 0.9
+                  }
+               },
+               "next_12_hours" : {
+                  "details" : {},
+                  "summary" : {
+                     "symbol_code" : "fair_day"
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0.1
+                  },
+                  "summary" : {
+                     "symbol_code" : "partlycloudy_day"
+                  }
+               }
+            },
+            "time" : "2024-03-26T12:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1023.1,
+                     "air_temperature" : 13.2,
+                     "cloud_area_fraction" : 28.1,
+                     "relative_humidity" : 73.8,
+                     "wind_from_direction" : 55.2,
+                     "wind_speed" : 1.2
+                  }
+               },
+               "next_6_hours" : {
+                  "details" : {
+                     "precipitation_amount" : 0
+                  },
+                  "summary" : {
+                     "symbol_code" : "fair_night"
+                  }
+               }
+            },
+            "time" : "2024-03-26T18:00:00Z"
+         },
+         {
+            "data" : {
+               "instant" : {
+                  "details" : {
+                     "air_pressure_at_sea_level" : 1025,
+                     "air_temperature" : 5.6,
+                     "cloud_area_fraction" : 0,
+                     "relative_humidity" : 99.5,
+                     "wind_from_direction" : 83.6,
+                     "wind_speed" : 2.1
+                  }
+               }
+            },
+            "time" : "2024-03-27T00:00:00Z"
+         }
+      ]
+   },
+   "type" : "Feature"
+}

--- a/forecastcache/forecastcache.go
+++ b/forecastcache/forecastcache.go
@@ -1,0 +1,49 @@
+package forecastcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+	"whats-the-weather/main/cache"
+
+	"github.com/zapling/yr.no-golang-client/locationforecast"
+)
+
+type funcTimeType func() time.Time
+
+type ForecastCache struct {
+	Cache *cache.Cache
+	TimeNow funcTimeType
+}
+
+type cachedForecast struct{
+	Forecast locationforecast.GeoJson
+	ExpiresAt time.Time
+}
+
+func (forecastCache *ForecastCache) Add(forecast locationforecast.GeoJson, until time.Time, key string) {
+	cachedObj := cachedForecast{Forecast: forecast, ExpiresAt: until}
+	jsonCachedObj, _ := json.Marshal(cachedObj)
+	var cachedObjNew locationforecast.GeoJson
+	json.Unmarshal(jsonCachedObj, &cachedObjNew)
+
+	forecastCache.Cache.Add(jsonCachedObj, key)
+}
+
+func (forecastCache *ForecastCache) Get(key string) (locationforecast.GeoJson, error){
+	cachedForecastObj := forecastCache.Cache.Get(key)
+	var cachedObjNew cachedForecast
+	json.Unmarshal([]byte(cachedForecastObj), &cachedObjNew)
+	fmt.Print(cachedObjNew.ExpiresAt)
+	checkExpiryAgainst := forecastCache.TimeNow()
+	if cachedForecastObj == "" {
+		return locationforecast.GeoJson{} , nil
+	}
+	if cachedObjNew.ExpiresAt.Sub(checkExpiryAgainst) > 0 {
+		return cachedObjNew.Forecast, nil
+	}else{
+		return locationforecast.GeoJson{} , nil
+	}
+}
+
+

--- a/forecastcache/forecastcache_test.go
+++ b/forecastcache/forecastcache_test.go
@@ -1,0 +1,85 @@
+package locationcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+	"whats-the-weather/main/cache"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zapling/yr.no-golang-client/locationforecast"
+)
+
+func futureTime() time.Time{
+	return time.Date(2998, time.January, 5, 0, 0, 0, 0, time.UTC)
+}
+
+func pastTime() time.Time{
+	return time.Date(1998, time.January, 5, 0, 0, 0, 0, time.UTC)
+}
+
+
+func TestLocationCache(t *testing.T) {
+	var forecast locationforecast.GeoJson
+	tempDir := t.TempDir()
+	dbPath := tempDir + "/db"
+	cacheFolder := tempDir + "/.cache"
+	testCache := cache.NewCache(dbPath, cacheFolder)
+
+	tests := []struct {
+		name string
+		expiryTime time.Time
+		mockForecastResponseFile string
+		want string
+		timeFunc time.Time
+		cacheKey string
+
+		}{
+			{
+				name: "Expired Cache",
+				expiryTime: time.Date(1998, time.January, 5, 0, 0, 0, 0, time.UTC),
+				mockForecastResponseFile: "../example_response.txt",
+				timeFunc: futureTime(),
+				cacheKey: "cacheKey",
+			},
+			{
+				name: "Valid Cache",
+				expiryTime: time.Date(2998, time.January, 5, 0, 0, 0, 0, time.UTC),
+				mockForecastResponseFile: "../example_response.txt",
+				timeFunc: pastTime(),
+				cacheKey: "secondCacheKey",
+
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+			getTimeFunc := func() time.Time {
+					return tt.timeFunc
+				}
+			forecastCache := ForecastCache{cache: testCache, timeNow: getTimeFunc }
+			expiryTime := tt.expiryTime
+			forecastResponse, err := os.Open(tt.mockForecastResponseFile)
+			if err != nil {
+				log.Fatalf("Error opening file: %v", err)
+			}
+			defer forecastResponse.Close()
+
+			decoder := json.NewDecoder(forecastResponse)
+			if err := decoder.Decode(&forecast); err != nil {
+				log.Fatalf("Error decoding JSON: %v", err)
+			}
+			fmt.Print(expiryTime)
+			forecastCache.Add(forecast, expiryTime, tt.cacheKey)
+
+			returnedFromCache, _ := forecastCache.Get(tt.cacheKey)
+			if forecastTimeseries := returnedFromCache.Properties.Timeseries; len(forecastTimeseries) > 0 {
+				assert.Equal(t, forecast, returnedFromCache )
+			} else {
+				fmt.Println("In here")
+			}
+		})
+	}}


### PR DESCRIPTION
Yr.no asks that the client caches responses. These changes add functionality on top of the existing cache implementation which allow us to add an expiry time for the cached object. The idea is that when the user requests a forecast, if the expiry time has passed, then we request a new forecast from yr.no.

After this was implemented, I noticed that bitcask have a `PutWithTTL`  method which handles the expiry time for you. If you request an object with a certain key and the TTL duration has passed, then an `ErrKeyExpired` error will be returned. 

I am going to try an implementation using `PutWithTTL`