### PR TITLE
Cache forecast with ttl

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestNewCache(t *testing.T) {
@@ -32,6 +33,23 @@ func TestAdd(t *testing.T) {
 	}
 }
 
+func TestAddWithTTL(t *testing.T) {
+	tempDir := t.TempDir()
+	dbPath := tempDir + "/db"
+	cacheFolder := tempDir + "/.cache"
+	cache := NewCache(dbPath, cacheFolder)
+	cache.AddWithTTL([]byte("test"), "key", time.Hour)
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Fatalf("DB folder not in expected location %v", err)
+	}
+
+	files, _ := os.ReadDir(cacheFolder)
+	if len(files) != 1 {
+		t.Fatalf("file not added to cache folder")
+	}
+}
+
 func TestGet(t *testing.T) {
 	tempDir := t.TempDir()
 	dbPath := tempDir + "/db"
@@ -39,8 +57,8 @@ func TestGet(t *testing.T) {
 	cache := NewCache(dbPath, cacheFolder)
 	cacheKey := "key"
 	cache.Add([]byte("test"), cacheKey)
-	
-	result := cache.Get(cacheKey)
+
+	result, _ := cache.Get(cacheKey)
 	 if result != "test" {
 	 	t.Fatalf("cached value not retrieved")
 	 }

--- a/cmd/location.go
+++ b/cmd/location.go
@@ -39,8 +39,8 @@ var locationCmd = &cobra.Command{
 
 		if coords != "" {
 			longLat := strings.Split(coords, ",")
-			longitude = longLat[0]
-			latitude = longLat[1]
+			longitude = longLat[1]
+			latitude = longLat[0]
 			fmt.Printf("Location: %s\n", args[0])
 		} else {
 			coordsAndPlaces, _ := geoClient.FindCoordinates(args[0])

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.3
 
 require (
 	barista.run v0.0.0-20231013003214-d5b04d179ffa
+	github.com/golang/protobuf v1.5.3
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/spf13/cobra v1.7.0
 	github.com/zapling/yr.no-golang-client v0.0.0-20210309083036-f048e27db764
@@ -19,6 +20,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20200228211341-fcea875c7e85 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -709,6 +711,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Why?
Each request to yr.no comes with an expiry time. We should not ask for
the same forecast again if the first one is not expired.

How?
Extend the cache package to use PutWithTTL to the database. This will
save an object. When we ask to retrieve that object, if it is expired
it will throw a KeyExpired error. We should then call the yr.no api

In order to allow this to happen, we need to change the cache
implementation to pass through the errors which are returned from
bitcask.
